### PR TITLE
Sc 96496/update qtwebkit build repo to build latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ on:
       - v*
 
 env:
-  QTWEBKIT: d1c854e2a214b5fad3c2e9906d6c2ba778d0a245
+  # As of writing this is the latest commit on the qt6-gha branch
+  QTWEBKIT: ee690e4d4f6a38b9c8e61e1e8ec6f538d725ef8c
 
 jobs:
   tar-src:
@@ -27,7 +28,7 @@ jobs:
           echo "short_version=${QTWEBKIT:0:7}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
-          repository: qtwebkit/qtwebkit
+          repository: movableink/webkit
           ref: ${{ env.QTWEBKIT }}
           submodules: true
           path: qtwebkit-src
@@ -87,10 +88,10 @@ jobs:
             libxcomposite-dev \
             libunwind-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
+        run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4
         with:
-          repository: qtwebkit/qtwebkit
+          repository: movableink/webkit
           ref: ${{ env.QTWEBKIT }}
           submodules: true
       - name: Configure
@@ -101,8 +102,8 @@ jobs:
             -G Ninja \
             -DPORT=Qt \
             -DCMAKE_BUILD_TYPE=Release \
-            -DQt5_DIR=/opt/qt5/lib/cmake/Qt5 \
-            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/opt/qt5" \
+            -DQt6_DIR=/opt/qt6/lib/cmake/Qt6 \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/opt/qt6" \
             -DCMAKE_INSTALL_LIBDIR=lib \
             -DKDE_INSTALL_LIBDIR=lib \
             ..
@@ -111,7 +112,7 @@ jobs:
         run: ninja install
       - name: Archive
         working-directory: ${{ github.workspace }}/opt
-        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt5
+        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt6
       - name: Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ on:
   push:
     tags:
       - v*
-    paths-ignore:
-      - '**/*.md'
 
 env:
   QTWEBKIT: d1c854e2a214b5fad3c2e9906d6c2ba778d0a245
@@ -27,7 +25,7 @@ jobs:
         run: |
           echo "artefact_name=qtwebkit-${QTWEBKIT:0:7}-src.tar.gz" >> $GITHUB_OUTPUT
           echo "short_version=${QTWEBKIT:0:7}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: qtwebkit/qtwebkit
           ref: ${{ env.QTWEBKIT }}
@@ -36,7 +34,7 @@ jobs:
       - name: Archive
         run: tar --create --xz --file "${{ steps.config.outputs.artefact_name }}" --exclude-vcs qtwebkit-src
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
           path: "${{ github.workspace }}/${{ steps.config.outputs.artefact_name }}"
@@ -48,8 +46,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: "ubuntu-18.04"
-            std: "17"
           - os: "ubuntu-22.04"
             std: "17"
 
@@ -92,7 +88,7 @@ jobs:
             libunwind-dev \
       - name: Install Qt
         run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: qtwebkit/qtwebkit
           ref: ${{ env.QTWEBKIT }}
@@ -117,7 +113,7 @@ jobs:
         working-directory: ${{ github.workspace }}/opt
         run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qt5
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
           path: "${{ github.workspace }}/opt/${{ steps.config.outputs.artefact_name }}"
@@ -156,7 +152,6 @@ jobs:
       matrix:
         config:
           - artefact: qtwebkit-${{ needs.tar-src.outputs.short_version }}-src.tar.gz
-          - artefact: qtwebkit-${{ needs.tar-src.outputs.short_version }}-cpp17-ubuntu-18.04-x64.tar.gz
           - artefact: qtwebkit-${{ needs.tar-src.outputs.short_version }}-cpp17-ubuntu-22.04-x64.tar.gz
     needs:
       - tar-src
@@ -164,7 +159,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "${{ matrix.config.artefact }}"
           path: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
             libharfbuzz-dev \
             libwebp-dev \
             libtasn1-6-dev \
+            libwoff-dev \
       - name: Install Qt
         run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,7 @@ jobs:
             libunwind-dev \
             libharfbuzz-dev \
             libwebp-dev \
+            libtasn1-6-dev \
       - name: Install Qt
         run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,7 @@ jobs:
             libxcomposite-dev \
             libunwind-dev \
             libharfbuzz-dev \
+            libwebp-dev \
       - name: Install Qt
         run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,7 @@ jobs:
             libgstreamer-plugins-base1.0-dev \
             libxcomposite-dev \
             libunwind-dev \
+            libharfbuzz-dev \
       - name: Install Qt
         run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
             libtasn1-6-dev \
             libwoff-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-test/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
+        run: curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1/qt-6.7.1-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - uses: actions/checkout@v4
         with:
           repository: movableink/webkit

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub actions runners.
 ## How to use this repo
 
 QtWebkit is no longer officially supported, so this repo builds it from an unofficial repo.
-It's version has been 5.212 for the last 5 years, so we clone and build from individual commit versions.
+It's version has been 5.212 for the last 5 years, so we clone and build from individual commit versions. We'll use version number 6.212 to indicate Qt version 6 compatible builds.
 Here's how:
 
 1. create a branch for the version you want (use whatever name seems sensible)
@@ -17,7 +17,7 @@ Here's how:
     2. check the artefacts it built are correct/work for you
     3. keep tweaking `main.yml` until the action builds the version you want successfully
 5. once you have a successful build, merge/rebase your PR into `main`
-6. Then tag the latest commit on `main` to trigger a release build. Tagging with something like "v5.212.0-X" where "X" is one higher than the last Release would make the most sense.
+6. Then tag the latest commit on `main` to trigger a release build. Tagging with something like "v6.212.0-X" where "X" is one higher than the last Release would make the most sense.
 
 Now to use the library you have built do something like:
 
@@ -43,5 +43,5 @@ This build requires cloning a built copy of Qt from our [qt-build](https://githu
 
 ### Trigger the release
 
-To trigger a release just push a tag that starts with `v`. Ideally push a tag of the format `v5.212.0-X` where "X" is a number one larger than the previous release. The release will use the tag you provide to both tag and name the release (so tag `v1.2.3` will produce `Release v1.2.3` with tag `v1.2.3`).
+To trigger a release just push a tag that starts with `v`. Ideally push a tag of the format `v6.212.0-X` where "X" is a number one larger than the previous release. The release will use the tag you provide to both tag and name the release (so tag `v1.2.3` will produce `Release v1.2.3` with tag `v1.2.3`).
 Simply pushing a tag will trigger the build process (on any branch), and then will create a Release using the result of that build. That release can be used via the `curl` process listed above.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,45 @@
 This project builds the official, unmodified, Qt Webkit source code for C++17 using
 GitHub actions runners.
 
+## How to use this repo
 
-## Installation
+QtWebkit is no longer officially supported, so this repo builds it from an unofficial repo.
+It's version has been 5.212 for the last 5 years, so we clone and build from individual commit versions.
+Here's how:
+
+1. create a branch for the version you want (use whatever name seems sensible)
+2. update `.github/workflows/main.yml` environment variable `QTWEBKIT` to specify the commit hash for the commit you want to build
+3. create a PR with your changes. This will trigger the CI to do a test build
+4. debug any issues
+    1. check the action suceeded
+    2. check the artefacts it built are correct/work for you
+    3. keep tweaking `main.yml` until the action builds the version you want successfully
+5. once you have a successful build, merge/rebase your PR into `main`
+6. Then tag the latest commit on `main` to trigger a release build. Tagging with something like "v5.212.0-X" where "X" is one higher than the last Release would make the most sense.
+
+Now to use the library you have built do something like:
 
 Using `curl` to download and extract to `/opt/qt5`:
 
     curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-$PLATFORM-x64.tar.gz | sudo tar -xJC /opt
 
 where `$PLATFORM` is `ubuntu-18.04` or `ubuntu-22.04`.
+
+## Details
+
+Here's some more info about how this repo works. It's basically just a workflow that pulls the QtWebkit source code, builds it, and then optionally produces a release.
+
+### The build
+
+The workflow will pull the Qt source code from the `qtwebkit/qtwebkit` github repo. 
+We use checkout specific commit hashes so we can get repeatable builds using the same source.
+
+### Trigger the build
+
+To trigger a build just create a PR and push to it. Every push will build Qtwebkit and provide the results as artefacts tied to the workflow run.
+This build requires cloning a built copy of Qt from our [qt-build](https://github.com/constructpm/qt-build) repo. If you've created a new release on that repo don't forget to update the workflow to use the new release.
+
+### Trigger the release
+
+To trigger a release just push a tag that starts with `v`. Ideally push a tag of the format `v5.212.0-X` where "X" is a number one larger than the previous release. The release will use the tag you provide to both tag and name the release (so tag `v1.2.3` will produce `Release v1.2.3` with tag `v1.2.3`).
+Simply pushing a tag will trigger the build process (on any branch), and then will create a Release using the result of that build. That release can be used via the `curl` process listed above.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here's some more info about how this repo works. It's basically just a workflow 
 
 ### The build
 
-The workflow will pull the Qt source code from the `qtwebkit/qtwebkit` github repo. 
+The workflow will pull the Qt source code from the `movableink/webkit` github repo (apparent successor to the `qtwebkit/qtwebkit` repo). 
 We use checkout specific commit hashes so we can get repeatable builds using the same source.
 
 ### Trigger the build


### PR DESCRIPTION
## Description

PR to update the version of QtWebkit we build to work with Qt6.
Also includes some polishing of the workflow and fleshing out of the readme.